### PR TITLE
Added document planning metaflow migration

### DIFF
--- a/docs/metaflow-migration.md
+++ b/docs/metaflow-migration.md
@@ -1,0 +1,17 @@
+# Metaflow/tsb migration
+
+The purpose of this document is to describe the relationship between the, at time of writing, the current metadata structure in metaflow and ODM2
+
+## mapping
+
+Below is a mapping between concepts in metaflow/tsb and their corresponding table in ODM2
+
+
+|metaflow ttype | tsb table | ODM2 metadata     | ODM2 data             |
+|---|---|---|---|
+| vessel      |      |   |   |
+| component      |      |   |   |
+| gpstrack      | track     | samplingfeatures  | trackresultlocations  |
+| tseries       | ts        | trackresults      | trackresultvalues     |
+| qctseries     | flag      |               |                   |
+


### PR DESCRIPTION
I attempted to make a document identifying the mapping between concepts in metaflow/tsb and ODM2 (and Roalds adapted version with trackresults)

PS: this is incomplete, but thought I'd just make a PR to start discussion.

