### PR TITLE
Expanded the FeatureActionsCreate schema to be more general

### DIFF
--- a/src/odm2_postgres_api/queries/core_queries.py
+++ b/src/odm2_postgres_api/queries/core_queries.py
@@ -162,7 +162,8 @@ async def create_feature_action(conn: asyncpg.connection, feature_action: schema
             "where samplingfeatureuuid = $1 OR samplingfeaturecode = $2), $3) "
             "ON CONFLICT (samplingfeatureid, actionid) DO UPDATE SET actionid = EXCLUDED.actionid returning *",
             feature_action.samplingfeatureuuid, feature_action.samplingfeaturecode, feature_action.actionid)
-        return schemas.FeatureActions(samplingfeatureuuid=feature_action.samplingfeatureuuid, **row)
+        return schemas.FeatureActions(samplingfeatureuuid=feature_action.samplingfeatureuuid,
+                                      samplingfeaturecode=feature_action.samplingfeaturecode, **row)
 
 
 async def create_result(conn: asyncpg.connection, result: schemas.ResultsCreate):

--- a/src/odm2_postgres_api/schemas/schemas.py
+++ b/src/odm2_postgres_api/schemas/schemas.py
@@ -403,8 +403,15 @@ class TaxonomicClassifier(TaxonomicClassifierCreate):
 
 
 class FeatureActionsCreate(BaseModel):
-    samplingfeatureuuid: uuid.UUID
+    samplingfeatureuuid: Optional[uuid.UUID] = None
+    samplingfeaturecode: Optional[str] = None
     actionid: int
+
+    @validator('samplingfeaturecode', always=True)
+    def must_supply_uuid_or_code(cls, v, values):
+        if not values['samplingfeatureuuid'] and not v:
+            raise ValueError('Must supply either valid uuid or valid code')
+        return v
 
 
 class FeatureActions(FeatureActionsCreate):
@@ -518,6 +525,12 @@ class PersonExtended(People):
 
 
 if __name__ == '__main__':
+    FeatureActionsCreate(samplingfeatureuuid='e4d0985a-1060-4766-8bb8-7d7b34d8b15a',
+                         samplingfeaturecode='A valid code', actionid=1)  # matching code and uuid checked by query
+    FeatureActionsCreate(samplingfeatureuuid='e4d0985a-1060-4766-8bb8-7d7b34d8b15a', actionid=1)
+    FeatureActionsCreate(samplingfeaturecode='A valid code', actionid=1)
+    # FeatureActionsCreate(actionid=1)  # Error!
+
     BeginDateTimeBase(begindatetime=dt.datetime.fromisoformat('2019-08-27T22:00:00+01:00'), begindatetimeutcoffset=1)
     # BeginDateTimeBase(begindatetime=dt.datetime.fromisoformat('2019-08-27T22:00:00+01:00'))  # Error!
     BeginDateTimeBase(begindatetime=dt.datetime.fromisoformat('2019-08-27T22:00:00+00:00'), begindatetimeutcoffset=0)


### PR DESCRIPTION
A feature_action row requires an actionid and a samplingfeatureid. Since
it proved cumbersome to keep track of samplingfeatureid's the schema
allowed for uuids instead and finds the associated samplingfeature.

Since both `samplingfeatureuuid` and `samplingfeaturecode` have a unique
constraint it makes sense to allow either when trying to find a
samplingfeatureid that should be referenced in a feature_action row. If
both a uuid and a code are supplied they have to both match to be
valid. If only one is supplied that one is simply used to query for a
samplingfeature.