### PR TITLE
Added two new endpoints to find units and variables through api

### DIFF
--- a/src/odm2_postgres_api/routes/begroing_routes.py
+++ b/src/odm2_postgres_api/routes/begroing_routes.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 
 from fastapi import Depends, Header, APIRouter
 
-from odm2_postgres_api.queries.core_queries import find_row, find_unit, get_unit
+from odm2_postgres_api.queries.core_queries import find_row, find_unit
 from odm2_postgres_api.routes.shared_routes import post_actions, post_results, post_categorical_results, \
     post_measurement_results
 from odm2_postgres_api.schemas.schemas import ProcessingLevels, UnitsCreate, Variables
@@ -139,10 +139,12 @@ async def post_indices(new_index: schemas.BegroingIndicesCreate,
 
     processing_level = await find_row(connection, "processinglevels", "processinglevelcode",
                                       "0", ProcessingLevels)
-    dimensionless_unit = await get_unit(connection, UnitsCreate(unitstypecv="Dimensionless", unitsabbreviation="-",
-                                                                unitsname="Dimensionless"))
-    seconds_unit = await get_unit(connection, UnitsCreate(unitstypecv="Time", unitsabbreviation="s",
-                                                          unitsname="second"))
+    dimensionless_unit = await find_unit(connection, UnitsCreate(unitstypecv="Dimensionless", unitsabbreviation="-",
+                                                                 unitsname="Dimensionless"), raise_if_none=True)
+    seconds_unit = await find_unit(connection, UnitsCreate(unitstypecv="Time", unitsabbreviation="s",
+                                                           unitsname="second"), raise_if_none=True)
+    if dimensionless_unit is None or seconds_unit is None:
+        raise ValueError('Units cannot be "None"')
 
     for index_instance in new_index.indices:
         variable = await find_row(connection, "variables", "variablenamecv", index_instance.indexType, Variables)

--- a/src/odm2_postgres_api/routes/shared_routes.py
+++ b/src/odm2_postgres_api/routes/shared_routes.py
@@ -1,4 +1,7 @@
+from typing import Union
+
 from fastapi import Depends, APIRouter
+from pydantic import constr
 
 from odm2_postgres_api.queries import core_queries
 from odm2_postgres_api.queries.core_queries import insert_pydantic_object, find_person_by_external_id
@@ -126,3 +129,17 @@ async def post_measurement_results(measurement_result: schemas.MeasurementResult
 async def post_categorical_results(categorical_result: schemas.CategoricalResultsCreate,
                                    connection=Depends(api_pool_manager.get_conn)):
     return await core_queries.upsert_categorical_result(connection, categorical_result)
+
+
+@router.get("/unit", response_model=schemas.Units)
+async def get_unit(unitstypecv: constr(max_length=255), unitsabbreviation: constr(max_length=50),  # type: ignore
+                   connection=Depends(api_pool_manager.get_conn)):
+    units_create = schemas.UnitsCreate(unitstypecv=unitstypecv, unitsabbreviation=unitsabbreviation, unitsname="")
+    return await core_queries.find_unit(connection, units_create, raise_if_none=True)
+
+
+@router.get("/variable", response_model=schemas.Variables)
+async def get_variable(variablecode: constr(max_length=50),  # type: ignore
+                       connection=Depends(api_pool_manager.get_conn)):
+    return await core_queries.find_row(connection, 'variables', 'variablecode',
+                                       variablecode, schemas.Variables, raise_if_none=True)


### PR DESCRIPTION
In order for both of these endpoints to be GET @zofiarudjord and I
decided not to use the UnitsCreate schema in the endpoint. The variable
endpoint naturally uses just a string in order to find the row.

We also did a small refactor to get rid of `get_unit` so that only
`find_unit` is left. This makes `find_unit` and `find_row` a little more
similar which seemed to be a little more readable.